### PR TITLE
Widget SearchView in MainActivity

### DIFF
--- a/app/src/main/java/mobi/mele/beers/extensions/AnyExtensions.kt
+++ b/app/src/main/java/mobi/mele/beers/extensions/AnyExtensions.kt
@@ -1,0 +1,15 @@
+package mobi.mele.beers.extensions
+
+import android.util.Log
+import mobi.mele.beers.BuildConfig
+
+/**
+ * Created by Antonio Fernández
+ * date   : 26/12/21
+ * e-mail : meleappdev@gmail.com
+ */
+fun Any?.log(tag : String = "mobi.mele.DEBUG"){
+    if(BuildConfig.DEBUG){
+        Log.d(tag,this.toString())
+    }
+}

--- a/app/src/main/java/mobi/mele/beers/ui/main/MainActivity.kt
+++ b/app/src/main/java/mobi/mele/beers/ui/main/MainActivity.kt
@@ -1,9 +1,16 @@
 package mobi.mele.beers.ui.main
 
+import android.app.SearchManager
+import android.content.Context
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
+import android.widget.SearchView
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import mobi.mele.beers.R
 import mobi.mele.beers.databinding.ActivityMainBinding
 import mobi.mele.beers.extensions.app
@@ -34,6 +41,10 @@ class MainActivity : AppCompatActivity() {
         }
 
         binding.recyclerBeers.adapter = beersAdapter
+
+        /*
+        * list beersMocked
+        */
         /*beersAdapter.beers = listOf(
             Beer(id = 1, name = "Buzz", abv = 4.5,
                 description = "A light, crisp and bitte…batch brewed only once.", image_url = "https://images.punkapi.com/v2/keg.png" ),
@@ -62,6 +73,56 @@ class MainActivity : AppCompatActivity() {
         beersAdapter.notifyDataSetChanged()
     }
 
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        /*
+        * Cómo configurar el widget de búsqueda: https://developer.android.com/guide/topics/search/search-dialog?hl=es-419
+        */
+        menuInflater.inflate(R.menu.search_option_menu, menu)
+
+        val searchManager = getSystemService(Context.SEARCH_SERVICE) as SearchManager
+        val menuItem = menu?.findItem(R.id.search)
+        val searchView = menuItem?.actionView as SearchView
+
+        searchView.setSearchableInfo(searchManager.getSearchableInfo(componentName))
+
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String?): Boolean {
+                /*if (!query.isNullOrBlank()) {
+                    searchBeers(query)
+                }*/
+                return false
+            }
+
+            override fun onQueryTextChange(newText: String?): Boolean {
+                if (!newText.isNullOrBlank()) {
+                    searchBeers(newText)
+                }
+                return true
+            }
+        })
+
+        /*
+        * Si queremos que al cargar la activity automáticamente se despliegue la opción de buscar
+        */
+        //menuItem.expandActionView()
+
+        menuItem.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
+            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+                searchView.isIconifiedByDefault = false
+                searchView.requestFocusFromTouch()
+                setEmptySerachView()
+                return true
+            }
+
+            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+                setRecipesInitialState()
+                return true
+            }
+        })
+
+        return true
+    }
+
     private fun updateUI(uiModelBeers: UIModelBeers) {
 
         binding.progress.visibility =
@@ -73,7 +134,7 @@ class MainActivity : AppCompatActivity() {
         notifyChangesToAdapter()
     }
 
-    private fun findBeers(query: String) {
+    private fun searchBeers(query: String) {
         mainViewModel.doSearch(query)
     }
 
@@ -81,8 +142,11 @@ class MainActivity : AppCompatActivity() {
         mainViewModel.refresh()
     }
 
+    private fun setEmptySerachView() {
+        mainViewModel.cleanResponseSearch()
+    }
+
     private fun notifyChangesToAdapter(){
         beersAdapter.notifyDataSetChanged()
     }
-
 }

--- a/app/src/main/java/mobi/mele/beers/ui/main/MainViewModel.kt
+++ b/app/src/main/java/mobi/mele/beers/ui/main/MainViewModel.kt
@@ -57,7 +57,15 @@ class MainViewModel(
     */
     fun doSearch(query: String) {
         viewModelScope.launch {
+            _uiModelBeers.value = UIModelBeers.Loading
             _uiModelBeers.value = UIModelBeers.Content(findBeersByNameUseCase.invoke(query))
+        }
+    }
+
+    fun cleanResponseSearch(){
+        viewModelScope.launch {
+            _uiModelBeers.value = UIModelBeers.Loading
+            _uiModelBeers.value = UIModelBeers.Content(emptyList())
         }
     }
 }

--- a/app/src/main/res/menu/search_option_menu.xml
+++ b/app/src/main/res/menu/search_option_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/search"
+        android:icon="@android:drawable/ic_menu_search"
+        android:title="@string/search_title"
+        app:actionViewClass="android.widget.SearchView"
+        app:showAsAction="collapseActionView|ifRoom" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Beers</string>
     <string name="recipe_not_available">Beer not available in this moment, try later. Thanks</string>
+    <string name="search_title">Buscar</string>
 </resources>


### PR DESCRIPTION
- Añadido onCreateOptionsMenu in MainActivity, inflamos el menú (search_option_menu, previamente creado en res/menu) search, 
- instanciado searchManager, menuItem y searchView
- en onMenuItemActionExpand añadido searchView.isIconifiedByDefault = false, searchView.requestFocusFromTouch() para que al pulsar sobre la opción search automáticamente tenga el focus la vista.
- vaciamos cada vez que queremos buscar setEmptySerachView().
- al salir de la opción search (onMenuItemActionCollapse) llamamos a setRecipesInitialState() para hacer una llamada y obtener las primeras veinticuatro cervezas.
- setOnQueryTextListener, solo implementamos onQueryTextChange porque no según la prueba técnica queremos que busque conforme se vayan introduciendo caracteres.